### PR TITLE
Items relating to debug flag being added

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,9 +6,9 @@ Todo list for esctl-go
 - [x] Separate elastic functions into their own package
 - [x] Add CI for building packages
 - [x] Add common badges to README
-- [ ] Add ability to switch between elastic clusters
+- [x] Add ability to switch between elastic clusters
   * [x] Via command
-  * [ ] Via flag
+  * [x] Via flag
 - [ ] Add automatic documentation for command usage (https://godoc.org/github.com/spf13/cobra/doc)
 - [x] Make top level command `esctl` display avaiable subcommands if no
   arguments are present
@@ -35,7 +35,8 @@ Todo list for esctl-go
   - [x] Show Inactive Watchers
 - [x] Add support for output format flag
 - [ ] Mock [Cluster](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html) apis
-- [ ] Improve error handling to be more verbose
+- [x] Improve error handling to be more verbose (somewhat complete, needs
+  improvement)
 - [x] Add API module to make requests in VERB ENDPOINT form to support not yet implemented endpoints
    * [x] MVP
    * [x] Support for output format flag and other existing flags
@@ -45,6 +46,23 @@ Todo list for esctl-go
    * [x] ~~Move api subcommand under escmd.~~ It shouldn't be considered an
      extension/option. Every subcommand should probably have its own package.
      Keeping the current structure
+- [ ] Mock functions from [kubectl
+  config](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#config)
+   * [x] current-context
+   * [ ] delete-cluster
+   * [ ] delete-context
+   * [ ] get-clusters
+   * [x] get-contexts
+   * [ ] rename-context
+   * [ ] set
+   * [ ] set-cluster
+   * [ ] set-context
+   * [ ] set-credentials
+   * [x] use-context
+   * [x] view (currently read)
+   * [x] generate
+   * [x] validate
+
 
 ## Function porting from https://github.com/slmingol/escli/blob/master/es_funcs.bash
 - [ ] escli_ls

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 require (
-	github.com/elastic/go-elasticsearch/v7 v7.3.0
+	github.com/elastic/go-elasticsearch/v7 v7.5.0
 	github.com/spf13/cobra v0.0.4
 	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-elasticsearch/v7 v7.3.0 h1:H29Nqf9cB9dVxX6LwS+zTDC2D4t9s+8dK8ln4HPS9rw=
 github.com/elastic/go-elasticsearch/v7 v7.3.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v7 v7.5.0 h1:kXW+EKls2BwsyQujTmVrxANb3U0qoz9wEq8Zkf/JEco=
+github.com/elastic/go-elasticsearch/v7 v7.5.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -17,6 +17,10 @@ var (
 	// Used for flags
 	outputFmt string
 	context   string
+	// What is the philosophical difference between debug and verbose?
+	// For now, debug stays and verbose does not
+	debug bool
+	// verbose bool
 )
 
 var rootCmd = &cobra.Command{
@@ -28,6 +32,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "", "choice of output format")
 	rootCmd.PersistentFlags().StringVarP(&context, "context", "c", "", "choice of context to use for a command")
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "debug connection")
 
 }
 
@@ -48,7 +53,7 @@ func genClient(ctx string) (client *elastic7.Client, err error) {
 	if err != nil {
 		return client, err
 	}
-	esConfig, err := escfg.GenESConfig(fileConfig, ctx)
+	esConfig, err := escfg.GenESConfig(fileConfig, ctx, debug)
 	if err != nil {
 		return client, err
 	}

--- a/pkg/escfg/escfg.go
+++ b/pkg/escfg/escfg.go
@@ -169,7 +169,7 @@ func askPass() (str string, err error) {
 	return str, err
 }
 
-func GenESConfig(cfg Config, ctx string) (es7cfg elastic7.Config, err error) {
+func GenESConfig(cfg Config, ctx string, debug bool) (es7cfg elastic7.Config, err error) {
 	// Order of operations
 	// --- Cluster ---
 	// Ordered by completeness of information
@@ -287,13 +287,19 @@ func GenESConfig(cfg Config, ctx string) (es7cfg elastic7.Config, err error) {
 	}
 
 	// Debug connection stuff. Should be wrapped in a feature flag
-	var debug bool = false
+	// There are a lot of debugging options. This will likely need to be extended
+	// in the future.
+	// https://godoc.org/github.com/elastic/go-elasticsearch/estransport#ColorLogger
 	if debug {
 		es7cfg.Logger = &estransport.ColorLogger{
-			Output:             os.Stdout,
-			EnableRequestBody:  true,
-			EnableResponseBody: true,
+			Output:            os.Stdout,
+			EnableRequestBody: true,
+			// Response body is not needed since that is already returned via
+			// esutil
+			EnableResponseBody: false,
 		}
+		es7cfg.EnableMetrics = true
+		es7cfg.EnableDebugLogger = true
 	}
 
 	return es7cfg, err


### PR DESCRIPTION
- Updated TODO.md with completed and new items
- Bumped github.com/elastic/go-elasticsearch/v7 from 7.3.0 to 7.5.0 to support
v7's elasticsearch.Config.EnableMetrics and
elasticsearch.Config.EnableDebugLogger fields. Currently unsure what those
fields do
- Added debug flag (--debug)
    This flag currently returns adds the full url of the request, the return
    code, and the time taken to make the request